### PR TITLE
Implement methods for reading from config file

### DIFF
--- a/protect-branches/go.mod
+++ b/protect-branches/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/google/go-github/v28 v28.1.1
 	golang.org/x/crypto v0.0.0-20191001170739-f9e2070545dc
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	gopkg.in/yaml.v2 v2.2.4
 )

--- a/protect-branches/go.sum
+++ b/protect-branches/go.sum
@@ -23,3 +23,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/protect-branches/handlers.go
+++ b/protect-branches/handlers.go
@@ -13,7 +13,7 @@ import (
 func handleGithubWebhook(w http.ResponseWriter, r *http.Request) {
 	logger := log.New(os.Stdout, "githubWebhook: ", log.LstdFlags)
 
-	payload, err := github.ValidatePayload(r, webhookSecret)
+	payload, err := github.ValidatePayload(r, []byte(githubWebhookSecret))
 	if err != nil {
 		logger.Printf("error validating request body: %v\n", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/protect-branches/handlers.go
+++ b/protect-branches/handlers.go
@@ -33,7 +33,15 @@ func handleGithubWebhook(w http.ResponseWriter, r *http.Request) {
 		if event.Action != nil && *event.Action == "created" {
 			logger.Printf("adding branch default branch protection policy for %s/%s\n", *event.Repo.Owner.Login, *event.Repo.Name)
 			githubBranchPolicy := NewGithubRepoPolicy()
-			githubBranchPolicy.createBranchProtection(*event.Repo.Owner.Login, *event.Repo.Name, "master")
+			err := retry(3, func() error {
+				err := githubBranchPolicy.createBranchProtection(*event.Repo.Owner.Login, *event.Repo.Name, "master")
+				return err
+			})
+			if err != nil {
+				logger.Printf("error creating branch protection: %v\n", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 		}
 	}
 }

--- a/protect-branches/retry.go
+++ b/protect-branches/retry.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func retry(attempts int, f func() error) error {
+	var err error
+
+	for i := 0; i < attempts; i++ {
+		err = f()
+		if err == nil {
+			return nil
+		}
+
+		time.Sleep(30 * time.Millisecond)
+	}
+	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
+}

--- a/protect-branches/server.go
+++ b/protect-branches/server.go
@@ -11,7 +11,6 @@ import (
 )
 
 var (
-	webhookSecret     = []byte("my-secret-key")
 	serverGracePeriod = 30 * time.Second
 )
 


### PR DESCRIPTION
This enables the service to read a github access token and a webhook secret from a config, instead of doing it from an environment variable or from the command line.
It also adds a retry function to make the service more robust.