### PR TITLE
Removed reference to GITHUB_ACCESS_TOKEN

### DIFF
--- a/protect-branches/github.go
+++ b/protect-branches/github.go
@@ -12,10 +12,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var (
-	githubTokenEnv = "GITHUB_AUTH_TOKEN"
-)
-
 type githubSecrets struct {
 	Token         string `yaml:"token"`
 	WebhookSecret string `yaml:"webhookSecret"`


### PR DESCRIPTION
use of environmnet variables was removed in favor of configuration
files.

Signed-off-by: alejandrox1 <alarcj137@gmail.com>